### PR TITLE
Gaze data management updates

### DIFF
--- a/SonoAssistScripts/config.json
+++ b/SonoAssistScripts/config.json
@@ -1,10 +1,10 @@
 {
-    "phys_screen_width" : 0.35,
-    "phys_screen_height" : 0.20,
+    "phys_screen_width" : 0.345,
+    "phys_screen_height" : 0.195,
     "max_gaze_speed" : 30,
     "head_data_slice_percentage" : 10,
+    "default_head_position" : 0.6,
     "saliency_map_width" : 50,
-    "saliency_map_min_points" : 5,
     "saliency_point_max_reach" : 11,
     "gaze_x_offset" : 0,
     "gaze_y_offset" : 0

--- a/SonoAssistScripts/generate_us_saliency_maps.py
+++ b/SonoAssistScripts/generate_us_saliency_maps.py
@@ -21,11 +21,11 @@ if __name__ == "__main__":
     config_file_path = ""
     output_video_path = ""
     '''
-    ex :  
+    ex : 
     config_file_path = "/home/one_wizard_boi/Documents/Projects/MedicalUltrasound/SonoAssist/SonoAssistScripts/config.json"
     output_video_path = "/home/one_wizard_boi/Documents/Projects/MedicalUltrasound/SonoAssist/SonoAssistScripts/us_video.avi"
     '''
-
+    
     # parsing script arguments
     parser = argparse.ArgumentParser()
     parser.add_argument("acquisition_dir", help="Directory containing the acquisition files")

--- a/SonoAssistScripts/sonopy/sonopy/config.py
+++ b/SonoAssistScripts/sonopy/sonopy/config.py
@@ -22,7 +22,7 @@ class ConfigurationManager():
 
         self.config_data = None
 
-        # laoding config from sources
+        # loading config from sources
         self.load_config_file()
         if acquisition_dir_path is not None: 
             self.load_acquisition_output_file()
@@ -47,7 +47,7 @@ class ConfigurationManager():
 
     def __getitem__(self, key):
 
-        ''' Short cut for reading config params '''
+        ''' Shortcut for reading config params '''
 
         if isinstance(key, str):
             return self.config_data[key]
@@ -57,7 +57,7 @@ class ConfigurationManager():
 
     def __setitem__(self, key, value):
 
-        ''' Short cut for writting config params '''
+        ''' Shortcut for writting config params '''
 
         if isinstance(key, str):
             self.config_data[key] = value
@@ -67,7 +67,7 @@ class ConfigurationManager():
 
     def __contains__(self, key):
 
-        ''' Short cut for membership check ''' 
+        ''' Shortcut for membership check ''' 
         
         if isinstance(key, str):
             return key in self.config_data

--- a/SonoAssistScripts/sonopy/sonopy/video.py
+++ b/SonoAssistScripts/sonopy/sonopy/video.py
@@ -2,7 +2,6 @@ import time
 from enum import Enum
 
 import cv2
-import imutils
 import numpy as np
 import pyrealsense2 as rs
 


### PR DESCRIPTION
	- Made it possible to use a pre-instantiated configuration
          manager

	- Saliency maps with no gaze points can be generated, they
          correspond to a map full of zeros.

	- Gaze data can be loaded even with no head position tracking
	  data. In this case, a default (head to screen) distance
	  measure is used.